### PR TITLE
Fix typo in the footer 

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -5,8 +5,8 @@ export default function Footer({systemInfo}) {
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
         <p data-testid="footer-content">
-          Organic is a project of 
-          <a href="https://ucsb-cs156.github.io"> CS156</a>, 
+          Organic is a project of{" "}
+          <a href="https://ucsb-cs156.github.io">CS156</a>, 
           a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage
           Github organizations associated with programming and software engineering courses.
           The open source code is available on

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -6,7 +6,7 @@ export default function Footer({systemInfo}) {
       <Container>
         <p data-testid="footer-content">
           Organic is a project of 
-          <a href="https://ucsb-cs156.github.io">CS156</a>, 
+          <a href="https://ucsb-cs156.github.io"> CS156</a>, 
           a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage
           Github organizations associated with programming and software engineering courses.
           The open source code is available on

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -8,7 +8,7 @@ describe("Footer tests", () => {
             <Footer systemInfo={systemInfoFixtures.showingAll}/>
         );
 
-        const expectedText = "Organic is a project ofCS156, a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
+        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
 
         
         const text = screen.getByTestId("footer-content");


### PR DESCRIPTION
Corrects the typo "Organic is a project ofCS156, a course..." in the footer, to "Organic is a project of CS156, a course..."

Deployed at: https://organic-joseph-foster-dev.dokku-05.cs.ucsb.edu/

Closes #31 
