### PR TITLE
Added Instructor Column to UserTable and Tests

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -29,6 +29,11 @@ const columns = [
         id: 'admin',
         accessor: (row, _rowIndex) => String(row.admin) // hack needed for boolean values to show up
     },
+    {
+        Header: 'Instructor',
+        id: 'instructor',
+        accessor: (row, _rowIndex) => String(row.instructor)
+    }
 ];
 
 export default function UsersTable({ users }) {

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -21,8 +21,8 @@ describe("UserTable tests", () => {
           <UsersTable users={usersFixtures.threeUsers}/>
         );
     
-        const expectedHeaders = ["githubId", "githubLogin", "fullName", "Email", "Last Online", "Admin"];
-        const expectedFields = ["githubId", "githubLogin", "fullName", "email", "lastOnline", "admin"];
+        const expectedHeaders = ["githubId", "githubLogin", "fullName", "Email", "Last Online", "Admin", "Instructor"];
+        const expectedFields = ["githubId", "githubLogin", "fullName", "email", "lastOnline", "admin", "instructor"];
         const testId = "UsersTable";
 
         expectedHeaders.forEach( (headerText)=> {
@@ -32,13 +32,14 @@ describe("UserTable tests", () => {
 
         expectedFields.forEach( (field)=> {
           const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-          expect(header).toBeInTheDocument();
+          expect(header).toBeInTheDocument();   
         });
 
         expect(screen.getByTestId(`${testId}-cell-row-0-col-githubId`)).toHaveTextContent("11111");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-fullName`)).toHaveTextContent("Phill Conrad");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-lastOnline`)).toHaveTextContent(formatTime(usersFixtures.threeUsers[0].lastOnline));
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("false");
         expect(screen.getByTestId(`${testId}-cell-row-1-col-githubLogin`)).toHaveTextContent("cgaucho");
         expect(screen.getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
       });


### PR DESCRIPTION
Added the Instructor Column to the UserTable and the corresponding tests in the UserTableTests as well. 

Review and make sure that the Instructor Column exists when rendering frontend.

Closes #26 