### PR TITLE
Pc alex put operation course suggestion2

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -4,12 +4,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
-import edu.ucsb.cs156.organic.errors.StaffNotFoundException;
 import edu.ucsb.cs156.organic.models.CurrentUser;
 import edu.ucsb.cs156.organic.services.CurrentUserService;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -39,9 +39,24 @@ public abstract class ApiController {
     return map;
   }
 
-  @ExceptionHandler({ EntityNotFoundException.class, StaffNotFoundException.class })
+  @ExceptionHandler({ EntityNotFoundException.class })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
+    return Map.of(
+      "type", e.getClass().getSimpleName(),
+      "message", e.getMessage()
+    );
+  }
+
+  /**
+   * Exception handler to return HTTP status code 403 Forbidden 
+   * when an AccessDeniedException is thrown
+   * @param e AccessDeniedException
+   * @return map with type and message
+   */
+  @ExceptionHandler({ AccessDeniedException.class })
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public Object handleAccessDeniedException(Throwable e) {
     return Map.of(
       "type", e.getClass().getSimpleName(),
       "message", e.getMessage()

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -32,6 +32,9 @@ import java.time.LocalDateTime;
 
 import javax.validation.Valid;
 
+import java.util.Optional;
+
+
 @Tag(name = "Courses")
 @RequestMapping("/api/courses")
 @RestController
@@ -146,20 +149,8 @@ public class CoursesController extends ApiController {
         User u = getCurrentUser().getUser();
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
-        Iterable<Staff> courseStaff = courseStaffRepository.findByCourseId(courseId);
-
-        //check if the user is a staff member of the course
-        boolean isStaff = false;
-        for (Staff staff : courseStaff) {
-            //log.info("staffId: {}, uId: {}, {}", staff.getGithubId(), u.getGithubId(), staff.getGithubId() == u.getGithubId());
-            if (staff.getGithubId().equals(u.getGithubId())) {
-                isStaff = true;
-                break;
-            }
-        }
-
-        if(!isStaff)
-            throw new StaffNotFoundException(u.getGithubId(), courseId);
+        courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
+        .orElseThrow(() -> new StaffNotFoundException(u.getGithubId(), courseId));
 
         course.setName(incoming.getName());
         course.setSchool(incoming.getSchool());

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -26,8 +26,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
-import edu.ucsb.cs156.organic.errors.StaffNotFoundException;
 
+import org.springframework.security.access.AccessDeniedException;
 import java.time.LocalDateTime;
 
 import javax.validation.Valid;
@@ -150,7 +150,8 @@ public class CoursesController extends ApiController {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
         courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
-        .orElseThrow(() -> new StaffNotFoundException(u.getGithubId(), courseId));
+        .orElseThrow(() -> new AccessDeniedException(
+            String.format("User %s is not authorized to update course %d", u.getGithubLogin(), courseId)));
 
         course.setName(incoming.getName());
         course.setSchool(incoming.getSchool());

--- a/src/main/java/edu/ucsb/cs156/organic/errors/StaffNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/organic/errors/StaffNotFoundException.java
@@ -1,8 +1,0 @@
-package edu.ucsb.cs156.organic.errors;
-
-public class StaffNotFoundException extends RuntimeException {
-  public StaffNotFoundException(Object staffId, Object courseId) {
-    super("Staff with Github id %s not found in course staff of course id %s"
-        .formatted(staffId.toString(), courseId.toString()));
-  }
-}

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/StaffRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/StaffRepository.java
@@ -12,4 +12,5 @@ public interface StaffRepository extends CrudRepository<Staff, Integer> {
     Iterable<Staff> findByCourseId(Long courseId);
     Iterable<Staff> findByGithubId(Integer githubId);
     Optional<Staff> findById(Long id);
+    Optional<Staff> findByCourseIdAndGithubId(Long courseId, Integer githubId);
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -332,17 +332,14 @@ public class CoursesControllerTests extends ControllerTestCase {
         public void admin_can_edit_an_existing_course() throws Exception {
                 // arrange
 
-                User user1 = User.builder().githubId(12345).githubLogin("scottpchow23").build();
+                User currentUser = currentUserService.getCurrentUser().getUser();
 
                 Staff courseStaff1 = Staff.builder()
                                 .id(111L)
                                 .courseId(course1.getId())
-                                .githubId(user1.getGithubId())
-                                .user(user1)
+                                .githubId(currentUser.getGithubId())
+                                .user(currentUser)
                                 .build();
-
-                ArrayList<Staff> expectedCourseStaff = new ArrayList<>();
-                expectedCourseStaff.addAll(Arrays.asList(courseStaff1));
 
                 Course courseAfter = Course.builder()
                                 .id(1L)
@@ -357,7 +354,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 String requestBody = mapper.writeValueAsString(courseAfter);
 
                 when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
-                when(courseStaffRepository.findByCourseId(eq(course1.getId()))).thenReturn(expectedCourseStaff);
+                when(courseStaffRepository.findByCourseIdAndGithubId(eq(course1.getId()),eq(courseStaff1.getGithubId()))).thenReturn(Optional.of(courseStaff1));
 
                 // act
                 MvcResult response = mockMvc.perform(
@@ -371,6 +368,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 // assert
                 verify(courseRepository, times(1)).findById(1L);
                 verify(courseRepository, times(1)).save(courseAfter); // should be saved with correct user
+                verify(courseStaffRepository, times(1)).findByCourseIdAndGithubId(eq(course1.getId()),eq(courseStaff1.getGithubId()));
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(requestBody, responseString);
         }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -412,12 +412,12 @@ public class CoursesControllerTests extends ControllerTestCase {
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
                                                 .with(csrf()))
-                                .andExpect(status().isNotFound()).andReturn();
+                                .andExpect(status().isForbidden()).andReturn();
 
                 // assert
                 verify(courseRepository, times(1)).findById(1L);
                 Map<String, Object> json = responseToJson(response);
-                assertEquals("Staff with Github id 12345 not found in course staff of course id 1", json.get("message"));
+                assertEquals("User cgaucho is not authorized to update course 1", json.get("message"));
         }
 
         


### PR DESCRIPTION
In this PR, we suggest some changes to `AlexPutOperationCourse`

* All of the changes in pc-AlexPutOperationCourse-suggestion (including refactoring the linear search to be a query
* Using an existing exception instead of creating a new one
* Using status code 403 instead of 404 when the intent is to show that an operation is not permitted due to security reasons.