### PR TITLE
Update 98-copy-issue-by-number.yml

### DIFF
--- a/.github/workflows/98-copy-issue-by-number.yml
+++ b/.github/workflows/98-copy-issue-by-number.yml
@@ -9,6 +9,8 @@ name: 98 - Copy specific issue from starter repo (creates new issue)
 env:
     GH_TOKEN: ${{ github.token }}
     STARTER: https://github.com/ucsb-cs156/proj-organic
+    TAG: f23
+
 on:
   workflow_dispatch:
     inputs:
@@ -29,7 +31,7 @@ jobs:
         id: get-issues
         run: |
           number=${{ github.event.inputs.issue_number }}
-          GH_REPO=${{env.STARTER}} gh issue list -s open -l M23 --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
+          GH_REPO=${{env.STARTER}} gh issue list -s open -l ${{env.TAG}} --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
           cat issues.json
           {
                echo 'issues<<THIS_IS_THIS_EOF_MARKER'


### PR DESCRIPTION
This PR updates workflow 98, which is used by staff to copy a single (by issue number) from the starter repo to the student team repos.   It is used for issues that are added after the initial run of workflow 99 which copies over everything with a certain tag.

Specifically, we update workflow 98 to use F23 instead of M23 as the tag, and factor out tag so that it can be more easily updated.

