### PR TITLE
Delete Course and Course Staff for CourseController

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -63,6 +63,15 @@ public abstract class ApiController {
     );
   }
 
+  /**
+   * Generic message to return in a controller method
+   * @param message
+   * @return map with message
+   */
+  protected Object genericMessage(String message) {
+    return Map.of("message", message);
+  }
+
   private ObjectMapper mapper;
 
   /**

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -27,10 +27,6 @@ public abstract class ApiController {
   protected CurrentUser getCurrentUser() {
     return currentUserService.getCurrentUser();
   }
-
-  protected Object genericMessage(String message) {
-    return Map.of("message", message);
-  }
   
   @ExceptionHandler({ IllegalArgumentException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -31,6 +31,7 @@ import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import java.time.LocalDateTime;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import java.util.Optional;
@@ -165,6 +166,7 @@ public class CoursesController extends ApiController {
         return course;
     }
 
+    @Transactional
     @Operation(summary = "Delete a course")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_INSTRUCTOR')")
     @DeleteMapping("/delete")
@@ -176,9 +178,10 @@ public class CoursesController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
         courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
         .orElseThrow(() -> new AccessDeniedException(
-            String.format("User %s is not authorized to update course %d", u.getGithubLogin(), courseId)));
+            String.format("User %s is not authorized to delete course %d", u.getGithubLogin(), courseId)));
 
         courseRepository.delete(course);
+        courseStaffRepository.deleteByCourseId(courseId);
         return genericMessage("Course with id %s deleted".formatted(courseId));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -151,9 +151,10 @@ public class CoursesController extends ApiController {
         User u = getCurrentUser().getUser();
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
-        courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
-        .orElseThrow(() -> new AccessDeniedException(
-            String.format("User %s is not authorized to update course %d", u.getGithubLogin(), courseId)));
+        if(!u.isAdmin())
+            courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
+            .orElseThrow(() -> new AccessDeniedException(
+                String.format("User %s is not authorized to update course %d", u.getGithubLogin(), courseId)));
 
         course.setName(incoming.getName());
         course.setSchool(incoming.getSchool());
@@ -176,9 +177,10 @@ public class CoursesController extends ApiController {
         User u = getCurrentUser().getUser();
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
-        courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
-        .orElseThrow(() -> new AccessDeniedException(
-            String.format("User %s is not authorized to delete course %d", u.getGithubLogin(), courseId)));
+        if(!u.isAdmin())
+            courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
+            .orElseThrow(() -> new AccessDeniedException(
+                String.format("User %s is not authorized to delete course %d", u.getGithubLogin(), courseId)));
 
         courseRepository.delete(course);
         courseStaffRepository.deleteByCourseId(courseId);

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/StaffRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/StaffRepository.java
@@ -13,4 +13,5 @@ public interface StaffRepository extends CrudRepository<Staff, Integer> {
     Iterable<Staff> findByGithubId(Integer githubId);
     Optional<Staff> findById(Long id);
     Optional<Staff> findByCourseIdAndGithubId(Long courseId, Integer githubId);
+    void deleteByCourseId(Long courseId);
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -642,55 +642,6 @@ public class CoursesControllerTests extends ControllerTestCase {
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("Course with id 1 not found", json.get("message"));
          }
-  
-        @WithMockUser(roles = { "ADMIN", "USER" })
-        @Test
-        public void admin_can_delete_staff() throws Exception {
-                // arrange
-                User user = User.builder().githubId(12345).githubLogin("jakedel").build();
-
-                Staff staff = Staff.builder()
-                                .id(15L)
-                                .courseId(course1.getId())
-                                .githubId(user.getGithubId())
-                                .user(user)
-                                .build();
-
-                when(courseStaffRepository.findById(eq(15L))).thenReturn(Optional.of(staff));
-
-                // act
-                MvcResult response = mockMvc.perform(
-                                delete("/api/courses/staff?id=15")
-                                                .with(csrf()))
-                                .andExpect(status().isOk()).andReturn();
-
-                // assert
-                verify(courseStaffRepository, times(1)).findById(15L);
-                verify(courseStaffRepository, times(1)).delete(any());
-
-                Map<String, Object> json = responseToJson(response);
-                assertEquals("Staff with id 15 deleted", json.get("message"));
-        }
-
-        @WithMockUser(roles = { "ADMIN", "USER" })
-        @Test
-        public void admin_tries_to_delete_non_existant_staff_and_gets_right_error_message()
-                        throws Exception {
-                // arrange
-
-                when(courseStaffRepository.findById(eq(15L))).thenReturn(Optional.empty());
-
-                // act
-                MvcResult response = mockMvc.perform(
-                                delete("/api/courses/staff?id=15")
-                                                .with(csrf()))
-                                .andExpect(status().isNotFound()).andReturn();
-
-                // assert
-                verify(courseStaffRepository, times(1)).findById(15L);
-                Map<String, Object> json = responseToJson(response);
-                assertEquals("Staff with id 15 not found", json.get("message"));
-        }
 
         // Tests for GET /api/RecommendationRequest?id=...
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -483,6 +483,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 // assert
                 verify(courseRepository, times(1)).findById(1L);
                 verify(courseRepository, times(1)).delete(any()); // should see some delete
+                verify(courseStaffRepository, times(1)).deleteByCourseId(any());
                 verify(courseStaffRepository, times(1)).findByCourseIdAndGithubId(eq(course1.getId()),eq(courseStaff1.getGithubId()));
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("Course with id 1 deleted", json.get("message"));
@@ -517,7 +518,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 // assert
                 verify(courseRepository, times(1)).findById(1L);
                 Map<String, Object> json = responseToJson(response);
-                assertEquals("User cgaucho is not authorized to update course 1", json.get("message"));
+                assertEquals("User cgaucho is not authorized to delete course 1", json.get("message"));
         }
 
         @WithMockUser(roles = { "ADMIN", "USER" })

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -456,4 +456,86 @@ public class CoursesControllerTests extends ControllerTestCase {
 
         }
 
+        //DELETE /api/courses/delete?courseId=... testing
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_an_existing_course() throws Exception {
+                // arrange
+
+                User currentUser = currentUserService.getCurrentUser().getUser();
+
+                Staff courseStaff1 = Staff.builder()
+                                .id(111L)
+                                .courseId(course1.getId())
+                                .githubId(currentUser.getGithubId())
+                                .user(currentUser)
+                                .build();
+
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
+                when(courseStaffRepository.findByCourseIdAndGithubId(eq(course1.getId()),eq(courseStaff1.getGithubId()))).thenReturn(Optional.of(courseStaff1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/courses/delete?courseId=1")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(courseRepository, times(1)).findById(1L);
+                verify(courseRepository, times(1)).delete(any()); // should see some delete
+                verify(courseStaffRepository, times(1)).findByCourseIdAndGithubId(eq(course1.getId()),eq(courseStaff1.getGithubId()));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Course with id 1 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void notstaff_admin_cannot_delete_an_existing_course() throws Exception {
+                // arrange
+
+                User user1 = User.builder().githubId(24689).githubLogin("randomGithubUsername").build();
+
+                Staff courseStaff1 = Staff.builder()
+                                .id(111L)
+                                .courseId(1L)
+                                .githubId(user1.getGithubId())
+                                .user(user1)
+                                .build();
+
+                ArrayList<Staff> expectedCourseStaff = new ArrayList<>();
+                expectedCourseStaff.addAll(Arrays.asList(courseStaff1));
+
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
+                when(courseStaffRepository.findByCourseIdAndGithubId(eq(course1.getId()),eq(courseStaff1.getGithubId()))).thenReturn(Optional.of(courseStaff1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/courses/delete?courseId=1")
+                                                .with(csrf()))
+                                .andExpect(status().isForbidden()).andReturn();
+
+                // assert
+                verify(courseRepository, times(1)).findById(1L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("User cgaucho is not authorized to update course 1", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_delete_course_that_does_not_exist() throws Exception {
+                // arrange
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/courses/delete?courseId=1")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(courseRepository, times(1)).findById(1L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Course with id 1 not found", json.get("message"));
+
+        }
 }


### PR DESCRIPTION
Implemented delete endpoint of CourseController which will delete the given course by courseId and all course staff that match this courseId.

Please review the use of @Transactional and deleting all of the course staff by a given courseId, not sure if this is the best way to do it.

Closes #21 