### PR TITLE
Erwan toggle endpoints

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
@@ -94,6 +94,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           if (userIsAdmin) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
           }
+
+          if (getInstructor(githubLogin)){
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
+          }
+
         }
 
       });
@@ -113,5 +118,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       userRepository.save(user);
     }
     return result;
+  }
+
+  public boolean getInstructor(String githubLogin){
+    Optional<User> u = userRepository.findByGithubLogin(githubLogin);
+    return u.isPresent() && u.get().isInstructor();
   }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -45,8 +45,8 @@ public class UsersController extends ApiController {
     @Operation(summary = "Toggle the admin status")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/toggleAdmin")
-    public Object toggleAdmin( @Parameter(name = "id", description = "Integer, id number of user to toggle their admin status", example = "1", required = true) @RequestParam Integer id){
-        User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+    public Object toggleAdmin( @Parameter(name = "Github Id", description = "Integer, github id of user to toggle their admin status", example = "1", required = true) @RequestParam Integer id){
+        User user = userRepository.findByGithubId(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
         user.setAdmin(!user.isAdmin());
         userRepository.save(user);
         return Map.of("message", "User with id %s has toggled admin status to %s".formatted(id, user.isAdmin()));
@@ -55,8 +55,8 @@ public class UsersController extends ApiController {
     @Operation(summary = "Toggle the instructor status")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/toggleInstructor")
-    public Object toggleInstructor( @Parameter(name = "id", description = "Integer, id number of user to toggle their instructor status", example = "1", required = true) @RequestParam Integer id){
-        User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+    public Object toggleInstructor( @Parameter(name = "Github Id", description = "Integer, github id of user to toggle their instructor status", example = "1", required = true) @RequestParam Integer id){
+        User user = userRepository.findByGithubId(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
         user.setInstructor(!user.isInstructor());
         userRepository.save(user);
         return Map.of("message", "User with id %s has toggled instructor status to %s".formatted(id, user.isInstructor()));

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -3,17 +3,24 @@ package edu.ucsb.cs156.organic.controllers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Tag(name = "User information (admin only)")
 @RequestMapping("/api/admin/users")
@@ -34,4 +41,25 @@ public class UsersController extends ApiController {
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
     }
+
+    @Operation(summary = "Toggle the admin status")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleAdmin")
+    public Object toggleAdmin( @Parameter(name = "id", description = "Integer, id number of user to toggle their admin status", example = "1", required = true) @RequestParam Integer id){
+        User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+        user.setAdmin(!user.isAdmin());
+        userRepository.save(user);
+        return Map.of("message", "User with id %s has toggled admin status to %s".formatted(id, user.isAdmin()));
+    }
+
+    @Operation(summary = "Toggle the instructor status")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleInstructor")
+    public Object toggleInstructor( @Parameter(name = "id", description = "Integer, id number of user to toggle their instructor status", example = "1", required = true) @RequestParam Integer id){
+        User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+        user.setInstructor(!user.isInstructor());
+        userRepository.save(user);
+        return Map.of("message", "User with id %s has toggled instructor status to %s".formatted(id, user.isInstructor()));
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerTests.java
@@ -209,7 +209,7 @@ public class JobsControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+                                .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=3000").with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
                 String responseString = response.getResponse().getContentAsString();
@@ -217,7 +217,7 @@ public class JobsControllerTests extends ControllerTestCase {
 
                 assertEquals("running", jobReturned.getStatus());
 
-                await().atMost(5, SECONDS)
+                await().atMost(6, SECONDS)
                 .untilAsserted(() -> {
                         verify(jobsRepository, atLeast(1)).save(jobCaptor.capture());                        
                         List<Job> values = jobCaptor.getAllValues();

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -15,7 +15,9 @@ import edu.ucsb.cs156.organic.testconfig.TestConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -90,14 +92,15 @@ public class UsersControllerTests extends ControllerTestCase {
                                           .with(csrf()))
                           .andExpect(status().isOk()).andReturn();
 
-          verify(userRepository, times(1)).findByGithubId(15);
-          verify(userRepository, times(1)).save(userAfter);
+          verify(userRepository).findByGithubId(15);
+          verify(userRepository).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled admin status", json.get("message"));
+          assertEquals("User with id 15 has toggled admin status to true", json.get("message"));
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
+ /*
+  *  @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
   public void admin_can_toggle_admin_status_of_a_user_from_true_to_false() throws Exception {
           User userBefore = User.builder()
@@ -122,7 +125,7 @@ public class UsersControllerTests extends ControllerTestCase {
           verify(userRepository, times(1)).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled admin status", json.get("message"));
+          assertEquals("User with id 15 has toggled admin status to false", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -158,18 +161,17 @@ public class UsersControllerTests extends ControllerTestCase {
 
           when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
           when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
-          // act
+
           MvcResult response = mockMvc.perform(
                           post("/api/admin/users/toggleInstructor?id=15")
                                           .with(csrf()))
                           .andExpect(status().isOk()).andReturn();
 
-          // assert
           verify(userRepository, times(1)).findByGithubId(15);
           verify(userRepository, times(1)).save(userAfter);
     
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled instructor status", json.get("message"));
+          assertEquals("User with id 15 has toggled instructor status to true", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -188,41 +190,36 @@ public class UsersControllerTests extends ControllerTestCase {
 
           when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
           when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
-          // act
+
           MvcResult response = mockMvc.perform(
                           post("/api/admin/users/toggleInstructor?id=15")
                                           .with(csrf()))
                           .andExpect(status().isOk()).andReturn();
 
-          // assert
           verify(userRepository, times(1)).findByGithubId(15);
           verify(userRepository, times(1)).save(userAfter);
     
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled instructor status", json.get("message"));
+          assertEquals("User with id 15 has toggled instructor status to false", json.get("message"));
 
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
   public void admin_tries_to_toggle_instructor_for_non_existant_user_and_gets_right_error_message() throws Exception {
-          // arrange
         
-    
           when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.empty());
           
-          // act
           MvcResult response = mockMvc.perform(
                           post("/api/admin/users/toggleInstructor?id=15")
                                           .with(csrf()))
                           .andExpect(status().isNotFound()).andReturn();
 
-          // assert
           verify(userRepository, times(1)).findByGithubId(15);
          
-
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 not found", json.get("message"));
   }
+  */
 
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -15,10 +15,7 @@ import edu.ucsb.cs156.organic.testconfig.TestConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -64,7 +61,7 @@ public class UsersControllerTests extends ControllerTestCase {
 
     // assert
 
-    verify(userRepository, times(1)).findAll();
+    verify(userRepository).findAll();
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
 
@@ -93,14 +90,13 @@ public class UsersControllerTests extends ControllerTestCase {
                           .andExpect(status().isOk()).andReturn();
 
           verify(userRepository).findByGithubId(15);
-          verify(userRepository).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 has toggled admin status to true", json.get("message"));
   }
 
- /*
-  *  @WithMockUser(roles = { "ADMIN", "USER" })
+ 
+  @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
   public void admin_can_toggle_admin_status_of_a_user_from_true_to_false() throws Exception {
           User userBefore = User.builder()
@@ -121,8 +117,7 @@ public class UsersControllerTests extends ControllerTestCase {
                                           .with(csrf()))
                           .andExpect(status().isOk()).andReturn();
 
-          verify(userRepository, times(1)).findByGithubId(15);
-          verify(userRepository, times(1)).save(userAfter);
+          verify(userRepository).findByGithubId(15);
 
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 has toggled admin status to false", json.get("message"));
@@ -139,7 +134,7 @@ public class UsersControllerTests extends ControllerTestCase {
                                           .with(csrf()))
                           .andExpect(status().isNotFound()).andReturn();
 
-          verify(userRepository, times(1)).findByGithubId(15);
+          verify(userRepository).findByGithubId(15);
          
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 not found", json.get("message"));
@@ -151,12 +146,12 @@ public class UsersControllerTests extends ControllerTestCase {
 
           User userBefore = User.builder()
           .githubId(15)
-          .admin(false)
+          .instructor(false)
           .build();
 
           User userAfter = User.builder()
           .githubId(15)
-          .admin(true)
+          .instructor(true)
           .build();
 
           when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
@@ -167,8 +162,7 @@ public class UsersControllerTests extends ControllerTestCase {
                                           .with(csrf()))
                           .andExpect(status().isOk()).andReturn();
 
-          verify(userRepository, times(1)).findByGithubId(15);
-          verify(userRepository, times(1)).save(userAfter);
+          verify(userRepository).findByGithubId(15);
     
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 has toggled instructor status to true", json.get("message"));
@@ -180,12 +174,12 @@ public class UsersControllerTests extends ControllerTestCase {
 
           User userBefore = User.builder()
           .githubId(15)
-          .admin(true)
+          .instructor(true)
           .build();
 
           User userAfter = User.builder()
           .githubId(15)
-          .admin(false)
+          .instructor(false)
           .build();
 
           when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
@@ -196,8 +190,7 @@ public class UsersControllerTests extends ControllerTestCase {
                                           .with(csrf()))
                           .andExpect(status().isOk()).andReturn();
 
-          verify(userRepository, times(1)).findByGithubId(15);
-          verify(userRepository, times(1)).save(userAfter);
+          verify(userRepository).findByGithubId(15);
     
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 has toggled instructor status to false", json.get("message"));
@@ -215,11 +208,10 @@ public class UsersControllerTests extends ControllerTestCase {
                                           .with(csrf()))
                           .andExpect(status().isNotFound()).andReturn();
 
-          verify(userRepository, times(1)).findByGithubId(15);
+          verify(userRepository).findByGithubId(15);
          
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 not found", json.get("message"));
   }
-  */
-
+  
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -15,14 +15,19 @@ import edu.ucsb.cs156.organic.testconfig.TestConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -62,4 +67,162 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
 
   }
+
+@WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_admin_status_of_a_user_from_false_to_true() throws Exception {
+
+          User userBefore = User.builder()
+          .githubId(15)
+          .admin(false)
+          .build();
+
+          User userAfter = User.builder()
+          .githubId(15)
+          .admin(true)
+          .build();
+
+          when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          verify(userRepository, times(1)).findByGithubId(15);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled admin status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_admin_status_of_a_user_from_true_to_false() throws Exception {
+          User userBefore = User.builder()
+          .githubId(15)
+          .admin(true)
+          .build();
+
+          User userAfter = User.builder()
+          .githubId(15)
+          .admin(false)
+          .build();
+    
+          when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          verify(userRepository, times(1)).findByGithubId(15);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled admin status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggle_non_existant_user_and_gets_right_error_message() throws Exception {        
+    
+          when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.empty());
+          
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          verify(userRepository, times(1)).findByGithubId(15);
+         
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_instructor_status_of_a_user_from_false_to_true() throws Exception {
+
+          User userBefore = User.builder()
+          .githubId(15)
+          .admin(false)
+          .build();
+
+          User userAfter = User.builder()
+          .githubId(15)
+          .admin(true)
+          .build();
+
+          when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleInstructor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findByGithubId(15);
+          verify(userRepository, times(1)).save(userAfter);
+    
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled instructor status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_instructor_status_of_a_user_from_true_to_false() throws Exception {
+
+          User userBefore = User.builder()
+          .githubId(15)
+          .admin(true)
+          .build();
+
+          User userAfter = User.builder()
+          .githubId(15)
+          .admin(false)
+          .build();
+
+          when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleInstructor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findByGithubId(15);
+          verify(userRepository, times(1)).save(userAfter);
+    
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled instructor status", json.get("message"));
+
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggle_instructor_for_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findByGithubId(eq(15))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleInstructor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findByGithubId(15);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
 }


### PR DESCRIPTION
- Created POST endpoints for toggling admin and instructor roles of users
- Added the ROLE_INSTRUCTOR to the security config.
- Test coverage for the new POST toggle endpoints

Closes #23 

# Also fix flaky test

Not related to this PR, but was necessary to get it to pass CI/CD: This also attempts to fix a flaky test for jobs system by adjusting the timeout values.