### PR TITLE
Added GET(single) operation for Course

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -63,6 +63,24 @@ public class CoursesController extends ApiController {
         }
     }
 
+    @Operation(summary= "Get a single course")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @GetMapping("")
+    public Course getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        User u = getCurrentUser().getUser();
+
+        Course course = courseRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, id));
+        
+        if(!u.isAdmin()){
+                courseStaffRepository.findByCourseIdAndGithubId(id, u.getGithubId())
+                        .orElseThrow(() -> new AccessDeniedException(
+                        String.format("User %s is not authorized to get course %d", u.getGithubLogin(), id)));
+        }
+        return course;
+    }
+
     @Operation(summary = "Create a new course")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
@@ -163,4 +181,6 @@ public class CoursesController extends ApiController {
         courseRepository.save(course);
         return course;
     }
+
+    
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -551,39 +551,4 @@ public class CoursesControllerTests extends ControllerTestCase {
                 assertEquals(String.format("User %s is not authorized to get course 1", currentUser.getGithubLogin()), json.get("message"));
         }
         
-        /*
-        @WithMockUser(roles = { "ADMIN", "USER" })
-        @Test
-        public void notadmin_notstaff_cannot_get_an_existing_course() throws Exception {
-                // arrange
-
-                User user1 = User.builder().githubId(24689).githubLogin("randomGithubUsername").build();
-
-                Staff courseStaff1 = Staff.builder()
-                                .id(111L)
-                                .courseId(1L)
-                                .githubId(user1.getGithubId())
-                                .user(user1)
-                                .build();
-
-                ArrayList<Staff> expectedCourseStaff = new ArrayList<>();
-                expectedCourseStaff.addAll(Arrays.asList(courseStaff1));
-
-                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
-                when(courseStaffRepository.findByCourseIdAndGithubId(eq(course1.getId()),
-                                eq(courseStaff1.getGithubId()))).thenReturn(Optional.of(courseStaff1));
-
-                // act
-                MvcResult response = mockMvc.perform(
-                                delete("/api/courses?id=1")
-                                                .with(csrf()))
-                                .andExpect(status().isForbidden()).andReturn();
-
-                // assert
-                verify(courseRepository, times(1)).findById(1L);
-                Map<String, Object> json = responseToJson(response);
-                assertEquals("User cgaucho is not authorized to get course 1", json.get("message"));
-        }
-        */
-        
 }


### PR DESCRIPTION
There is a GET endpoint /api/course/get?id=123 that gets the course with id 123 if you are an admin, or if you are logged in and on the course staff.

There are tests for the GET endpoint.

Closes #20 