### PR TITLE
Added Index Page for Courses, fixed 500 error

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,7 @@ import LoadingPage from "main/pages/LoadingPage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
 
-import CourseIndexPage from "main/pages/Courses/CoursesCreatePage";
+import CourseIndexPage from "main/pages/Courses/CourseIndexPage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminJobsPage from "main/pages/AdminJobsPage";
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,7 @@ import LoadingPage from "main/pages/LoadingPage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
 
-import CourseIndexPage from "main/pages/Courses/CourseIndexPage";
+import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminJobsPage from "main/pages/AdminJobsPage";
 
@@ -34,7 +34,7 @@ function App() {
     : <Route path="/" element={<LoginPage />} />;
 
   const courseRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) 
-    ? <Route path="/courses" element={<CourseIndexPage />} /> 
+    ? <Route path="/courses" element={<CoursesIndexPage />} /> 
     : null;
 
   /*  Display the LoadingPage while awaiting currentUser 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,8 @@ import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
 
 import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
+import CoursesEditPage from "main/pages/Courses/CoursesEditPage";
+import CoursesCreatePage from "main/pages/Courses/CoursesCreatePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminJobsPage from "main/pages/AdminJobsPage";
 
@@ -34,7 +36,11 @@ function App() {
     : <Route path="/" element={<LoginPage />} />;
 
   const courseRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) 
-    ? <Route path="/courses" element={<CoursesIndexPage />} /> 
+    ? <>
+        <Route path="/courses" element={<CoursesIndexPage />} /> 
+        <Route path="/courses/edit/:id" element={<CoursesEditPage />} /> 
+        <Route path="/courses/create" element={<CoursesCreatePage />} /> 
+      </>
     : null;
 
   /*  Display the LoadingPage while awaiting currentUser 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import LoadingPage from "main/pages/LoadingPage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
 
+import CourseIndexPage from "main/pages/Courses/CoursesCreatePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminJobsPage from "main/pages/AdminJobsPage";
 
@@ -31,6 +32,10 @@ function App() {
   const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
     ? <Route path="/" element={<HomePage />} /> 
     : <Route path="/" element={<LoginPage />} />;
+
+  const courseRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) 
+    ? <Route path="/courses" element={<CourseIndexPage />} /> 
+    : null;
 
   /*  Display the LoadingPage while awaiting currentUser 
       response to prevent the NotFoundPage from displaying */
@@ -66,6 +71,7 @@ function App() {
           {homeRoute}
           {adminRoutes}
           {userRoutes}
+          {courseRoute}
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       )}

--- a/frontend/src/fixtures/coursesFixtures.js
+++ b/frontend/src/fixtures/coursesFixtures.js
@@ -4,8 +4,8 @@ const coursesFixtures = {
         "name": "CS156",
         "school": "UCSB",
         "term": "F23",
-        "start": "2023-09-24T12:00:00",
-        "end": "2023-12-15T12:00:00",
+        "startDate": "2023-09-24T12:00:00",
+        "endDate": "2023-12-15T12:00:00",
         "githubOrg": "ucsb-cs156-f23"
     },
     threeCourses: [
@@ -14,8 +14,8 @@ const coursesFixtures = {
             "name": "CS156",
             "school": "UCSB",
             "term": "F23",
-            "start": "2023-09-24T12:00:00",
-            "end": "2023-12-15T12:00:00",
+            "startDate": "2023-09-24T12:00:00",
+            "endDate": "2023-12-15T12:00:00",
             "githubOrg": "ucsb-cs156-f23"
         },
         {
@@ -23,8 +23,8 @@ const coursesFixtures = {
             "name": "CS162",
             "school": "UCSB",
             "term": "W24",
-            "start": "2023-01-08T12:00:00",
-            "end": "2023-03-22T12:00:00",
+            "startDate": "2023-01-08T12:00:00",
+            "endDate": "2023-03-22T12:00:00",
             "githubOrg": "ucsb-cs162-w24"
         },
         {
@@ -32,8 +32,8 @@ const coursesFixtures = {
             "name": "testName",
             "school": "testSchool",
             "term": "testTerm",
-            "start": "2023-03-03T12:00:00",
-            "end": "2024-03-03T12:00:00",
+            "startDate": "2023-03-03T12:00:00",
+            "endDate": "2024-03-03T12:00:00",
             "githubOrg": "testGithubOrg"
         }
     ]

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -136,6 +136,70 @@ const apiCurrentUserFixtures = {
 
 
     },
+    instructorUser: {
+        "user":
+        {
+            "githubId": 1119018,
+            "githubNodeId": "MDQ6VXNlcjExMTkwMTc=",
+            "githubLogin": "cgaucho",
+            "email": "cgaucho@cs.ucsb.edu",
+            "pictureUrl": "https://avatars.githubusercontent.com/u/1119017?v=4",
+            "fullName": "Chris Gaucho",
+            "emailVerified": true,
+            "admin": false,
+            "instructor": true,
+            "accessToken": "ghu_Du4W9ThisIsNotARealTokenEither1w9SuT",
+            "emails": [{
+                "email": "cgaucho@cs.ucsb.edu",
+                "githubId": 1119018
+            },
+            ],
+            "lastOnline": "2023-11-09T21:06:11.131913Z"
+        },
+        "roles": [
+            { "authority": "SCOPE_email" },
+            {
+                "authority": "ROLE_USER",
+                "attributes": {
+                    "login": "cgaucho",
+                    "id": 1119018,
+                    "node_id": "MDQ6VXNlcjExMTkwMTc=",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/1119017?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/cgaucho",
+                    "html_url": "https://github.com/cgaucho",
+                    "followers_url": "https://api.github.com/users/cgaucho/followers",
+                    "following_url": "https://api.github.com/users/cgaucho/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/cgaucho/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/cgaucho/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/cgaucho/subscriptions",
+                    "organizations_url": "https://api.github.com/users/cgaucho/orgs",
+                    "repos_url": "https://api.github.com/users/cgaucho/repos",
+                    "events_url": "https://api.github.com/users/cgaucho/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/cgaucho/received_events",
+                    "type": "User",
+                    "site_admin": false,
+                    "name": "Chris Gaucho",
+                    "company": "UC Santa Barbara",
+                    "blog": "http://www.cs.ucsb.edu/~cgaucho",
+                    "location": "Santa Barbara, CA",
+                    "email": null,
+                    "hireable": null,
+                    "bio": null,
+                    "twitter_username": null,
+                    "public_repos": 267,
+                    "public_gists": 1,
+                    "followers": 81,
+                    "following": 12,
+                    "created_at": "2011-10-11T09:33:28Z",
+                    "updated_at": "2023-11-08T20:14:48Z"
+                }
+            },
+            { "authority": "SCOPE_profile" }]
+
+
+
+    },
 };
 
 const currentUserFixtures = {

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -132,9 +132,6 @@ const apiCurrentUserFixtures = {
                 }
             },
             { "authority": "SCOPE_profile" }]
-
-
-
     },
     instructorUser: {
         "user":
@@ -196,9 +193,6 @@ const apiCurrentUserFixtures = {
                 }
             },
             { "authority": "SCOPE_profile" }]
-
-
-
     },
 };
 
@@ -210,6 +204,16 @@ const currentUserFixtures = {
             rolesList: [
                 "ROLE_USER",
                 "ROLE_ADMIN"
+            ]
+        },
+    },
+    instructorUser: {
+        loggedIn: true,
+        root: {
+            ...(apiCurrentUserFixtures.adminUser),
+            rolesList: [
+                "ROLE_USER",
+                "ROLE_INSTRUCTOR"
             ]
         },
     },

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -192,6 +192,7 @@ const apiCurrentUserFixtures = {
                     "updated_at": "2023-11-08T20:14:48Z"
                 }
             },
+            { "authority": "ROLE_INSTRUCTOR"},
             { "authority": "SCOPE_profile" }]
     },
 };

--- a/frontend/src/main/components/Courses/CoursesForm.js
+++ b/frontend/src/main/components/Courses/CoursesForm.js
@@ -97,35 +97,35 @@ function CoursesForm({ initialContents, submitAction, buttonLabel = "Create" }) 
             <Row>
                 <Col>
                     <Form.Group className="mb-3" >
-                            <Form.Label htmlFor="start">Start (iso format)</Form.Label>
+                            <Form.Label htmlFor="startDate">Start (iso format)</Form.Label>
                             <Form.Control
-                                data-testid={testIdPrefix + "-start"}
-                                id="start"
+                                data-testid={testIdPrefix + "-startDate"}
+                                id="startDate"
                                 type="datetime-local"
-                                isInvalid={Boolean(errors.start)}
-                                {...register("start", { 
-                                    required: "Start is required." 
+                                isInvalid={Boolean(errors.startDate)}
+                                {...register("startDate", { 
+                                    required: "StartDate is required." 
                                 })}
                             />
                             <Form.Control.Feedback type="invalid">
-                                {errors.start?.message}
+                                {errors.startDate?.message}
                             </Form.Control.Feedback>
                     </Form.Group>
                 </Col>
                 <Col>
                     <Form.Group className="mb-3" >
-                            <Form.Label htmlFor="end">End (iso format)</Form.Label>
+                            <Form.Label htmlFor="endDate">End (iso format)</Form.Label>
                             <Form.Control
-                                data-testid={testIdPrefix + "-end"}
-                                id="end"
+                                data-testid={testIdPrefix + "-endDate"}
+                                id="endDate"
                                 type="datetime-local"
-                                isInvalid={Boolean(errors.end)}
-                                {...register("end", { 
-                                    required: "End is required." 
+                                isInvalid={Boolean(errors.endDate)}
+                                {...register("endDate", { 
+                                    required: "EndDate is required." 
                                 })}
                             />
                             <Form.Control.Feedback type="invalid">
-                                {errors.end?.message}
+                                {errors.endDate?.message}
                             </Form.Control.Feedback>
                     </Form.Group>
                 </Col>

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -44,11 +44,11 @@ export default function CoursesTable({ courses, currentUser }) {
         },
         {
             Header: 'Start Date',
-            accessor: 'start',
+            accessor: 'startDate',
         },
         {
             Header: 'End Date',
-            accessor: 'end',
+            accessor: 'endDate',
         },
         {
             Header: 'GitHub Org',

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -52,7 +52,13 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
             </Nav>
-
+            {
+              currentUser && currentUser.loggedIn && (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) && (
+                <>
+                  <Nav.Link as={Link} to="/courses">Courses</Nav.Link>
+                </>
+              )
+            }
             <Nav className="ml-auto">
               {
                 currentUser && currentUser.loggedIn ? (

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -53,7 +53,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
             </Nav>
             {
-              currentUser && currentUser.loggedIn && (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) && (
+              (hasRole(currentUser, "ROLE_INSTRUCTOR") || hasRole(currentUser, "ROLE_ADMIN")) && (
                 <>
                   <Nav.Link as={Link} to="/courses">Courses</Nav.Link>
                 </>

--- a/frontend/src/main/pages/Courses/CoursesCreatePage.js
+++ b/frontend/src/main/pages/Courses/CoursesCreatePage.js
@@ -13,8 +13,8 @@ export default function CoursesCreatePage({storybook=false}) {
       name: course.name,
       school: course.school,
       term: course.term,
-      start: course.start,
-      end: course.end,
+      startDate: course.startDate,
+      endDate: course.endDate,
       githubOrg: course.githubOrg
     }
   });

--- a/frontend/src/main/pages/Courses/CoursesEditPage.js
+++ b/frontend/src/main/pages/Courses/CoursesEditPage.js
@@ -26,7 +26,7 @@ export default function RecommendationRequestEditPage({storybook=false}) {
     url: "/api/courses",
     method: "PUT",
     params: {
-      id: course.id,
+      courseId: course.id,
     },
     data: {
       name: course.name,

--- a/frontend/src/main/pages/Courses/CoursesEditPage.js
+++ b/frontend/src/main/pages/Courses/CoursesEditPage.js
@@ -1,0 +1,73 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import CoursesForm from "main/components/Courses/CoursesForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function RecommendationRequestEditPage({storybook=false}) {
+  let { id } = useParams();
+
+  const { data: course, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/courses?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/courses`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (course) => ({
+    url: "/api/courses",
+    method: "PUT",
+    params: {
+      id: course.id,
+    },
+    data: {
+      name: course.name,
+      school: course.school,
+      term: course.term,
+      start: course.start,
+      end: course.end,
+      githubOrg: course.githubOrg
+    }
+  });
+
+  const onSuccess = (course) => {
+    toast(`Course updated - id: ${course.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/courses?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/courses" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit Course</h1>
+        {
+          course && <CoursesForm initialContents={course} submitAction={onSubmit} buttonLabel="Update" />
+        }
+      </div>
+    </BasicLayout>
+  )
+}
+

--- a/frontend/src/main/pages/Courses/CoursesEditPage.js
+++ b/frontend/src/main/pages/Courses/CoursesEditPage.js
@@ -32,8 +32,8 @@ export default function RecommendationRequestEditPage({storybook=false}) {
       name: course.name,
       school: course.school,
       term: course.term,
-      start: course.start,
-      end: course.end,
+      startDate: course.startDate,
+      endDate: course.endDate,
       githubOrg: course.githubOrg
     }
   });

--- a/frontend/src/main/pages/Courses/CoursesIndexPage.js
+++ b/frontend/src/main/pages/Courses/CoursesIndexPage.js
@@ -1,14 +1,45 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import CoursesTable from 'main/components/Courses/CoursesTable';
+import { Button } from 'react-bootstrap';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser';
 
 export default function CoursesIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
+  const { data: currentUser } = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) {
+        return (
+            <Button
+                variant="primary"
+                href="/courses/create"
+                style={{ float: "right" }}
+            >
+                Create Course
+            </Button>
+        )
+    } 
+  }
+  
+  const { data: courses, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/courses/all"],
+      // Stryker disable next-line all
+      { method: "GET", url: "/api/courses/all" },
+      // Stryker disable next-line all : don't test empty
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/placeholder/create">Create</a></p>
-        <p><a href="/placeholder/edit/1">Edit</a></p>
+        {createButton()}
+        <h1>Courses</h1>
+        <CoursesTable courses={courses} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Courses/CoursesIndexPage.js
+++ b/frontend/src/main/pages/Courses/CoursesIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function CoursesIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/stories/components/Nav/AppNavbar.stories.js
+++ b/frontend/src/stories/components/Nav/AppNavbar.stories.js
@@ -25,6 +25,11 @@ basic_loggedInAdminUser.args = {
     currentUser: currentUserFixtures.adminUser
 };
 
+export const basic_loggedInInstructorUser = Template.bind({});
+basic_loggedInInstructorUser.args = {
+    currentUser: currentUserFixtures.instructorUser
+};
+
 export const basic_loggedInRegularUser = Template.bind({});
 basic_loggedInRegularUser.args = {
     currentUser: currentUserFixtures.userOnly

--- a/frontend/src/stories/pages/Courses/CoursesEditPage.stories.js
+++ b/frontend/src/stories/pages/Courses/CoursesEditPage.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { coursesFixtures } from "fixtures/coursesFixtures";
+import { rest } from "msw";
+
+import CoursesEditPage from "main/pages/Courses/CoursesEditPage";
+
+export default {
+    title: 'pages/Courses/CoursesEditPage',
+    component: CoursesEditPage
+};
+
+const Template = () => <CoursesEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.threeCourses[0]));
+        }),
+        rest.put('/api/courses', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/stories/pages/Courses/CoursesIndexPage.stories.js
+++ b/frontend/src/stories/pages/Courses/CoursesIndexPage.stories.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { coursesFixtures } from "fixtures/coursesFixtures";
+import { rest } from "msw";
+
+import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
+
+export default {
+    title: 'pages/Courses/CoursesIndexPage',
+    component: CoursesIndexPage
+};
+
+const Template = () => <CoursesIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses/all', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.threeCourses));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses/all', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.threeCourses));
+        }),
+        rest.delete('/api/courses', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/components/Courses/CoursesForm.test.js
+++ b/frontend/src/tests/components/Courses/CoursesForm.test.js
@@ -45,8 +45,8 @@ describe("CoursesForm tests", () => {
                 <CoursesForm />
             </Router>
         );
-        await screen.findByTestId("CoursesForm-start");
-        const startField = screen.getByTestId("CoursesForm-start");
+        await screen.findByTestId("CoursesForm-startDate");
+        const startField = screen.getByTestId("CoursesForm-startDate");
         const submitButton = screen.getByTestId("CoursesForm-submit");
 
         fireEvent.change(startField, { target: { value: 'bad-input' } });
@@ -68,8 +68,8 @@ describe("CoursesForm tests", () => {
         await screen.findByText(/Name is required./);
         expect(screen.getByText(/School is required./)).toBeInTheDocument();
         expect(screen.getByText(/Term is required./)).toBeInTheDocument();
-        expect(screen.getByText(/Start is required./)).toBeInTheDocument();
-        expect(screen.getByText(/End is required./)).toBeInTheDocument();
+        expect(screen.getByText(/StartDate is required./)).toBeInTheDocument();
+        expect(screen.getByText(/EndDate is required./)).toBeInTheDocument();
         expect(screen.getByText(/GithubOrg is required./)).toBeInTheDocument();
     });
 
@@ -88,8 +88,8 @@ describe("CoursesForm tests", () => {
         const nameField = screen.getByTestId("CoursesForm-name");
         const schoolField = screen.getByTestId("CoursesForm-school");
         const termField = screen.getByTestId("CoursesForm-term");
-        const startField = screen.getByTestId("CoursesForm-start");
-        const endField = screen.getByTestId("CoursesForm-end");
+        const startField = screen.getByTestId("CoursesForm-startDate");
+        const endField = screen.getByTestId("CoursesForm-endDate");
         const githubOrgField = screen.getByTestId("CoursesForm-githubOrg");
         const submitButton = screen.getByTestId("CoursesForm-submit");
 

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -31,7 +31,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Course Name", "School", "Term", "Start Date", "End Date", "GitHub Org"];
-    const expectedFields = ["id", "name", "school", "term", "start", "end", "githubOrg"];
+    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
     const testId = "coursesTable";
 
     // assert
@@ -61,7 +61,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Course Name", "School", "Term", "Start Date", "End Date", "GitHub Org"];
-    const expectedFields = ["id", "name", "school", "term", "start", "end", "githubOrg"];
+    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
     const testId = "CoursesTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -104,7 +104,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Course Name", "School", "Term", "Start Date", "End Date", "GitHub Org"];
-    const expectedFields = ["id", "name", "school", "term", "start", "end", "githubOrg"];
+    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
     const testId = "CoursesTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -41,6 +41,68 @@ describe("AppNavbar tests", () => {
         expect(adminMenu).toBeInTheDocument();        
     });
 
+    test("renders the Course link for admins", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await screen.findByText("Courses");
+        const link = screen.getByText("Courses");
+        expect(link).toBeInTheDocument();
+        expect(link.getAttribute("href")).toBe("/courses");
+    });
+
+    /*
+        test("renders the Course link for instructors", async () => {
+        
+        const currentUser = currentUserFixtures.instructorUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await screen.findByText("Courses");
+        const link = screen.getByText("Courses");
+        expect(link).toBeInTheDocument();
+        expect(link.getAttribute("href")).toBe("/courses");
+    })
+    */
+
+    test("doesnt render the Course link for non admin/instructor", async () => {
+        
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.queryByText("Courses")).not.toBeInTheDocument();
+    });
+
     test("renders correctly for user that hasn't signed in", async () => {
         const currentUser = currentUserFixtures.not_logged_in;
         const doLogin = jest.fn();

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -62,7 +62,6 @@ describe("AppNavbar tests", () => {
         expect(link.getAttribute("href")).toBe("/courses");
     });
 
-    /*
         test("renders the Course link for instructors", async () => {
         
         const currentUser = currentUserFixtures.instructorUser;
@@ -83,7 +82,7 @@ describe("AppNavbar tests", () => {
         expect(link).toBeInTheDocument();
         expect(link.getAttribute("href")).toBe("/courses");
     })
-    */
+    
 
     test("doesnt render the Course link for non admin/instructor", async () => {
         

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -58,8 +58,8 @@ describe("CourseCreatePage tests", () => {
             name: "CS156",
             school: "UCSB",
             term: "F23",
-            start: "2023-09-24T12:00:00",
-            end: "2023-12-15T12:00:00",
+            startDate: "2023-09-24T12:00:00",
+            endDate: "2023-12-15T12:00:00",
             githubOrg: "ucsb-cs156-f23"
         };
 
@@ -80,8 +80,8 @@ describe("CourseCreatePage tests", () => {
         const nameField = screen.getByTestId("CoursesForm-name");
         const schoolField = screen.getByTestId("CoursesForm-school");
         const termField = screen.getByTestId("CoursesForm-term");
-        const startField = screen.getByTestId("CoursesForm-start");
-        const endField = screen.getByTestId("CoursesForm-end");
+        const startField = screen.getByTestId("CoursesForm-startDate");
+        const endField = screen.getByTestId("CoursesForm-endDate");
         const githubOrgField = screen.getByTestId("CoursesForm-githubOrg");
         const submitButton = screen.getByTestId("CoursesForm-submit");
 
@@ -103,8 +103,8 @@ describe("CourseCreatePage tests", () => {
                 "name": "CS156",
                 "school": "UCSB",
                 "term": "F23",
-                "start": "2023-09-24T12:00",
-                "end": "2023-12-15T12:00",
+                "startDate": "2023-09-24T12:00",
+                "endDate": "2023-12-15T12:00",
                 "githubOrg": "ucsb-cs156-f23"
         });
 

--- a/frontend/src/tests/pages/Courses/CoursesEditPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesEditPage.test.js
@@ -1,0 +1,199 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import CoursesEditPage from "main/pages/Courses/CoursesEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("CoursesEditPage tests", () => {
+
+    describe("when the backend doesn't return data", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/courses", { params: { id: 17 } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <CoursesEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit Course");
+            expect(screen.queryByTestId("CoursesForm-name")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/courses", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                name: "CS156",
+                school: "UCSB",
+                term: "F23",
+                start: "2023-09-24T12:00",
+                end: "2023-12-15T12:00",
+                githubOrg: "ucsb-cs156-f23"
+            });
+            axiosMock.onPut('/api/courses').reply(200, {
+                id: 17,
+                name: "CS162",
+                school: "UCSB2",
+                term: "W24",
+                start: "2023-01-08T12:00",
+                end: "2023-03-22T12:00",
+                githubOrg: "ucsb-cs162-w24"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <CoursesEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <CoursesEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("CoursesForm-name");
+
+            const idField = screen.getByTestId("CoursesForm-id");
+            const nameField = screen.getByTestId("CoursesForm-name");
+            const schoolField = screen.getByTestId("CoursesForm-school");
+            const termField = screen.getByTestId("CoursesForm-term");
+            const startField = screen.getByTestId("CoursesForm-start");
+            const endField = screen.getByTestId("CoursesForm-end");
+            const githubOrgField = screen.getByTestId("CoursesForm-githubOrg");
+            const submitButton = screen.getByTestId("CoursesForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(nameField).toHaveValue("CS156");
+            expect(schoolField).toHaveValue("UCSB");
+            expect(termField).toHaveValue("F23");
+            expect(startField).toHaveValue("2023-09-24T12:00");
+            expect(endField).toHaveValue("2023-12-15T12:00");
+            expect(githubOrgField).toHaveValue("ucsb-cs156-f23");
+
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <CoursesEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("CoursesForm-name");
+
+            const idField = screen.getByTestId("CoursesForm-id");
+            const nameField = screen.getByTestId("CoursesForm-name");
+            const schoolField = screen.getByTestId("CoursesForm-school");
+            const termField = screen.getByTestId("CoursesForm-term");
+            const startField = screen.getByTestId("CoursesForm-start");
+            const endField = screen.getByTestId("CoursesForm-end");
+            const githubOrgField = screen.getByTestId("CoursesForm-githubOrg");
+            const submitButton = screen.getByTestId("CoursesForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(nameField).toHaveValue("CS156");
+            expect(schoolField).toHaveValue("UCSB");
+            expect(termField).toHaveValue("F23");
+            expect(startField).toHaveValue("2023-09-24T12:00");
+            expect(endField).toHaveValue("2023-12-15T12:00");
+            expect(githubOrgField).toHaveValue("ucsb-cs156-f23");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(nameField, { target: { value: 'CS162' } });
+            fireEvent.change(schoolField, { target: { value: 'UCSB2' } });
+            fireEvent.change(termField, { target: { value: 'W24' } });
+            fireEvent.change(startField, { target: { value: '2023-01-08T12:00' } });
+            fireEvent.change(endField, { target: { value: '2023-03-22T12:00' } });
+            fireEvent.change(githubOrgField, { target: { value: 'ucsb-cs162-w24' } });
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("Course updated - id: 17");
+            expect(mockNavigate).toBeCalledWith({ "to": "/courses" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                name: "CS162",
+                school: "UCSB2",
+                term: "W24",
+                start: "2023-01-08T12:00",
+                end: "2023-03-22T12:00",
+                githubOrg: "ucsb-cs162-w24"
+            })); // posted object
+
+        });
+
+       
+    });
+});

--- a/frontend/src/tests/pages/Courses/CoursesEditPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesEditPage.test.js
@@ -182,7 +182,7 @@ describe("CoursesEditPage tests", () => {
             expect(mockNavigate).toBeCalledWith({ "to": "/courses" });
 
             expect(axiosMock.history.put.length).toBe(1); // times called
-            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].params).toEqual({ courseId: 17 });
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
                 name: "CS162",
                 school: "UCSB2",

--- a/frontend/src/tests/pages/Courses/CoursesEditPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesEditPage.test.js
@@ -79,8 +79,8 @@ describe("CoursesEditPage tests", () => {
                 name: "CS156",
                 school: "UCSB",
                 term: "F23",
-                start: "2023-09-24T12:00",
-                end: "2023-12-15T12:00",
+                startDate: "2023-09-24T12:00",
+                endDate: "2023-12-15T12:00",
                 githubOrg: "ucsb-cs156-f23"
             });
             axiosMock.onPut('/api/courses').reply(200, {
@@ -88,8 +88,8 @@ describe("CoursesEditPage tests", () => {
                 name: "CS162",
                 school: "UCSB2",
                 term: "W24",
-                start: "2023-01-08T12:00",
-                end: "2023-03-22T12:00",
+                startDate: "2023-01-08T12:00",
+                endDate: "2023-03-22T12:00",
                 githubOrg: "ucsb-cs162-w24"
             });
         });
@@ -121,8 +121,8 @@ describe("CoursesEditPage tests", () => {
             const nameField = screen.getByTestId("CoursesForm-name");
             const schoolField = screen.getByTestId("CoursesForm-school");
             const termField = screen.getByTestId("CoursesForm-term");
-            const startField = screen.getByTestId("CoursesForm-start");
-            const endField = screen.getByTestId("CoursesForm-end");
+            const startField = screen.getByTestId("CoursesForm-startDate");
+            const endField = screen.getByTestId("CoursesForm-endDate");
             const githubOrgField = screen.getByTestId("CoursesForm-githubOrg");
             const submitButton = screen.getByTestId("CoursesForm-submit");
 
@@ -153,8 +153,8 @@ describe("CoursesEditPage tests", () => {
             const nameField = screen.getByTestId("CoursesForm-name");
             const schoolField = screen.getByTestId("CoursesForm-school");
             const termField = screen.getByTestId("CoursesForm-term");
-            const startField = screen.getByTestId("CoursesForm-start");
-            const endField = screen.getByTestId("CoursesForm-end");
+            const startField = screen.getByTestId("CoursesForm-startDate");
+            const endField = screen.getByTestId("CoursesForm-endDate");
             const githubOrgField = screen.getByTestId("CoursesForm-githubOrg");
             const submitButton = screen.getByTestId("CoursesForm-submit");
 
@@ -187,8 +187,8 @@ describe("CoursesEditPage tests", () => {
                 name: "CS162",
                 school: "UCSB2",
                 term: "W24",
-                start: "2023-01-08T12:00",
-                end: "2023-03-22T12:00",
+                startDate: "2023-01-08T12:00",
+                endDate: "2023-03-22T12:00",
                 githubOrg: "ucsb-cs162-w24"
             })); // posted object
 

--- a/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("CoursesIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
@@ -9,7 +9,6 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { coursesFixtures } from "fixtures/coursesFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import mockConsole from "jest-mock-console";
 
 
 const mockToast = jest.fn();

--- a/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
@@ -1,17 +1,32 @@
-import { render, screen } from "@testing-library/react";
-import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
+
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { coursesFixtures } from "fixtures/coursesFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("CoursesIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "CoursesTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,11 +35,25 @@ describe("CoursesIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
-        setupUserOnly();
+    const setupInstructorUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.instructorUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("Renders with Create Button for admin user", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/all").reply(200, []);
 
         // act
         render(
@@ -36,11 +65,116 @@ describe("CoursesIndexPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor( ()=>{
+            expect(screen.getByText(/Create Course/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Course/);
+        expect(button).toHaveAttribute("href", "/courses/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("Renders with Create Button for instructor user", async () => {
+        // arrange
+        setupInstructorUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/all").reply(200, []);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor( ()=>{
+            expect(screen.getByText(/Create Course/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Course/);
+        expect(button).toHaveAttribute("href", "/courses/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three courses correctly for regular user", async () => {
+        
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/all").reply(200, coursesFixtures.threeCourses);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        // assert that the Create button is not present when user isn't an admin
+        expect(screen.queryByText(/Create Course/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/all").timeout();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/all").reply(200, coursesFixtures.threeCourses);
+        axiosMock.onDelete("/api/courses").reply(200, "Course with id 1 was deleted");
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        // act
+        fireEvent.click(deleteButton);
+
+        // assert
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Course with id 1 was deleted") });
+
     });
 
 });
-
-

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -91,8 +91,8 @@ public class CoursesController extends ApiController {
             @Parameter(name = "name", description ="course name, e.g. CMPSC 156" ) @RequestParam String name,
             @Parameter(name = "school", description ="school abbreviation e.g. UCSB" ) @RequestParam String school,
             @Parameter(name = "term", description = "quarter or semester, e.g. F23") @RequestParam String term,
-            @Parameter(name = "startDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-            @Parameter(name = "endDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @Parameter(name = "startDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(name = "endDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @Parameter(name = "githubOrg", description = "for example ucsb-cs156-f23" ) @RequestParam String githubOrg)
             throws JsonProcessingException {
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -91,8 +91,8 @@ public class CoursesController extends ApiController {
             @Parameter(name = "name", description ="course name, e.g. CMPSC 156" ) @RequestParam String name,
             @Parameter(name = "school", description ="school abbreviation e.g. UCSB" ) @RequestParam String school,
             @Parameter(name = "term", description = "quarter or semester, e.g. F23") @RequestParam String term,
-            @Parameter(name = "start", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @Parameter(name = "end", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @Parameter(name = "startDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(name = "endDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @Parameter(name = "githubOrg", description = "for example ucsb-cs156-f23" ) @RequestParam String githubOrg)
             throws JsonProcessingException {
 
@@ -100,8 +100,8 @@ public class CoursesController extends ApiController {
                 .name(name)
                 .school(school)
                 .term(term)
-                .start(start)
-                .end(end)
+                .startDate(startDate)
+                .endDate(endDate)
                 .githubOrg(githubOrg)
                 .build();
 
@@ -201,8 +201,8 @@ public class CoursesController extends ApiController {
         course.setName(incoming.getName());
         course.setSchool(incoming.getSchool());
         course.setTerm(incoming.getTerm());
-        course.setStart(incoming.getStart());
-        course.setEnd(incoming.getEnd());
+        course.setStartDate(incoming.getStartDate());
+        course.setEndDate(incoming.getEndDate());
         course.setGithubOrg(incoming.getGithubOrg());
 
         courseRepository.save(course);

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -185,7 +185,7 @@ public class CoursesController extends ApiController {
 
     @Operation(summary = "Update a course")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_INSTRUCTOR')")
-    @PutMapping("/update")
+    @PutMapping("")
     public Course updateCourse(
             @Parameter(name = "courseId") @RequestParam Long courseId,
             @RequestBody @Valid Course incoming) throws JsonProcessingException {
@@ -212,20 +212,20 @@ public class CoursesController extends ApiController {
     @Transactional
     @Operation(summary = "Delete a course")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_INSTRUCTOR')")
-    @DeleteMapping("/delete")
+    @DeleteMapping("")
     public Object deleteCourse(
-            @Parameter(name = "courseId") @RequestParam Long courseId) throws JsonProcessingException {
+            @Parameter(name = "id") @RequestParam Long id) throws JsonProcessingException {
         
         User u = getCurrentUser().getUser();
-        Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+        Course course = courseRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, id.toString()));
         if(!u.isAdmin())
-            courseStaffRepository.findByCourseIdAndGithubId(courseId, u.getGithubId())
+            courseStaffRepository.findByCourseIdAndGithubId(id, u.getGithubId())
             .orElseThrow(() -> new AccessDeniedException(
-                String.format("User %s is not authorized to delete course %d", u.getGithubLogin(), courseId)));
+                String.format("User %s is not authorized to delete course %d", u.getGithubLogin(), id)));
 
         courseRepository.delete(course);
-        courseStaffRepository.deleteByCourseId(courseId);
-        return genericMessage("Course with id %s deleted".formatted(courseId));
+        courseStaffRepository.deleteByCourseId(id);
+        return genericMessage("Course with id %s deleted".formatted(id));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
@@ -19,7 +19,7 @@ public class Course {
   private String name;
   private String school;
   private String term;
-  private LocalDateTime start;
-  private LocalDateTime end;
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
   private String githubOrg;
 }

--- a/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
+++ b/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
@@ -34,7 +34,7 @@
               },
               {
                 "column": {
-                  "name": "END",
+                  "name": "END_DATE",
                   "type": "TIMESTAMP"
                 }
               },
@@ -58,7 +58,7 @@
               },
               {
                 "column": {
-                  "name": "START",
+                  "name": "START_DATE",
                   "type": "TIMESTAMP"
                 }
               },

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -170,7 +170,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/courses/post?name=CS16&school=UCSB&term=F23&start=2023-09-01T00:00:00&end=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                                post("/api/courses/post?name=CS16&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -81,8 +81,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                         .name("CS156")
                         .school("UCSB")
                         .term("F23")
-                        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                         .githubOrg("ucsb-cs156-f23")
                         .build();
 
@@ -91,8 +91,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                         .name("CS148")
                         .school("UCSB")
                         .term("S24")
-                        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
-                        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
                         .githubOrg("ucsb-cs148-w24")
                         .build();
 
@@ -151,8 +151,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 
@@ -161,8 +161,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 
@@ -334,8 +334,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS36")
                                 .school("TUCSB")
                                 .term("M25")
-                                .start(LocalDateTime.parse("2024-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2025-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2024-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2025-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs36-m25")
                                 .build();
 
@@ -381,8 +381,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS36")
                                 .school("TUCSB")
                                 .term("M25")
-                                .start(LocalDateTime.parse("2024-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2025-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2024-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2025-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs36-m25")
                                 .build();
 
@@ -424,8 +424,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS36")
                                 .school("TUCSB")
                                 .term("M25")
-                                .start(LocalDateTime.parse("2024-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2025-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2024-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2025-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs36-m25")
                                 .build();
 
@@ -463,8 +463,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("TUCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -323,7 +323,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 assertEquals(expectedMap, responseMap);
         }
 
-        //PUT /api/courses/update?courseId=... testing
+        //PUT /api/courses?courseId=... testing
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
@@ -345,7 +345,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/courses/update?courseId=1")
+                                put("/api/courses?courseId=1")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -393,7 +393,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/courses/update?courseId=1")
+                                put("/api/courses?courseId=1")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -437,7 +437,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/courses/update?courseId=1")
+                                put("/api/courses?courseId=1")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -474,7 +474,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/courses/update?courseId=67")
+                                put("/api/courses?courseId=67")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -612,7 +612,7 @@ public class CoursesControllerTests extends ControllerTestCase {
         }
         
 
-        // Tests for DELETE /api/courses/delete?courseId=...
+        // Tests for DELETE /api/courses?id=...
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
@@ -623,7 +623,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/courses/delete?courseId=1")
+                                delete("/api/courses?id=1")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -658,7 +658,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/courses/delete?courseId=1")
+                                delete("/api/courses?id=1")
                                                 .with(csrf()))
                                 .andExpect(status().isForbidden()).andReturn();
 
@@ -688,7 +688,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/courses/delete?courseId=1")
+                                delete("/api/courses?id=1")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -710,7 +710,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                 delete("/api/courses/delete?courseId=1")
+                                 delete("/api/courses?id=1")
                                                  .with(csrf()))
                                  .andExpect(status().isNotFound()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
@@ -89,8 +89,8 @@ public class StudentsControllerTests extends ControllerTestCase {
                         .name("CS156")
                         .school("UCSB")
                         .term("F23")
-                        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                         .githubOrg("ucsb-cs156-f23")
                         .build();
 
@@ -99,8 +99,8 @@ public class StudentsControllerTests extends ControllerTestCase {
                         .name("CS148")
                         .school("UCSB")
                         .term("S24")
-                        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
-                        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
                         .githubOrg("ucsb-cs148-w24")
                         .build();
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UserInfoControllerTests.java
@@ -126,8 +126,8 @@ public class UserInfoControllerTests extends ControllerTestCase {
         .name("CS156")
         .school("UCSB")
         .term("F23")
-        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+        .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+        .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
         .githubOrg("ucsb-cs156-f23")
         .build();
 
@@ -136,8 +136,8 @@ public class UserInfoControllerTests extends ControllerTestCase {
         .name("CS148")
         .school("UCSB")
         .term("S24")
-        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
-        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+        .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+        .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
         .githubOrg("ucsb-cs148-w24")
         .build();
 


### PR DESCRIPTION
Implemented Index Page for courses with storybook and tests. 

I changed every single instance of start or end to startDate and endDate to fix the 500 error caused by the end keyword.

I also fixed some bugs where the edit and delete was not communicating correctly with the backend.

Screenshot:
![image](https://github.com/ucsb-cs156-f23/proj-organic-f23-6pm-1/assets/69696671/3a66914f-3879-438a-b40b-7d8a9cf84d58)

Storybook link: https://ucsb-cs156-f23.github.io/proj-organic-f23-6pm-1/prs/62/storybook/?path=/story/components-jobs-jobstable--emptytable

Deployment link: https://organic-joseph-foster-dev.dokku-05.cs.ucsb.edu/

Closes #13 