### PR TITLE
pc - try to resolve flaky test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerFailureTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerFailureTests.java
@@ -1,0 +1,134 @@
+package edu.ucsb.cs156.organic.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.awaitility.Awaitility.await;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.entities.jobs.Job;
+import edu.ucsb.cs156.organic.repositories.UserRepository;
+import edu.ucsb.cs156.organic.repositories.jobs.JobsRepository;
+import edu.ucsb.cs156.organic.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+@Slf4j
+@WebMvcTest(controllers = JobsController.class)
+@Import(JobService.class)
+@AutoConfigureDataJpa
+public class JobsControllerFailureTests extends ControllerTestCase {
+
+        @Captor
+        ArgumentCaptor<Job> jobCaptor;
+
+        @MockBean
+        JobsRepository jobsRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        @Autowired
+        JobService jobService;
+
+        @Autowired
+        ObjectMapper objectMapper;
+
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_test_job_that_fails() throws Exception {
+
+                // arrange
+
+                User user = currentUserService.getUser();
+
+                Job jobStarted = Job.builder()
+                                .id(0L)
+                                .createdBy(user)
+                                .createdAt(null)
+                                .updatedAt(null)
+                                .status("running")
+                                .log("Hello World! from test job!")
+                                .build();
+
+                Job jobFailed = Job.builder()
+                                .id(0L)
+                                .createdBy(user)
+                                .createdAt(null)
+                                .updatedAt(null)
+                                .status("error")
+                                .log("Hello World! from test job!\nFail!")
+                                .build();
+
+                when(jobsRepository.save(eq(jobStarted))).thenReturn(jobStarted);
+                when(jobsRepository.save(eq(jobFailed))).thenReturn(jobFailed);
+
+                // act
+                MvcResult response = mockMvc
+                                .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=2000").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                String responseString = response.getResponse().getContentAsString();
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertEquals("running", jobReturned.getStatus());
+
+                await().atMost(8, SECONDS)
+                                .untilAsserted(() -> {
+                                        verify(jobsRepository, atLeast(3)).save(jobCaptor.capture());
+                                });
+
+                List<Job> values = jobCaptor.getAllValues();
+                log.info("values.size()={}", values.size());
+                log.info("values={}", values);
+
+                boolean errorFound = false;
+                for (Job j : values) {
+                        log.info("j={}", j);
+                        if (j.getStatus().equals("error")) {
+                                errorFound = true;
+                                break;
+                        }
+                }
+                assertTrue(errorFound, "should have found at least one value with status error");
+        }
+
+}

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerTests.java
@@ -169,61 +169,14 @@ public class JobsControllerTests extends ControllerTestCase {
                 assertEquals("running", jobReturned.getStatus());
 
                 await().atMost(5, SECONDS)
-                .untilAsserted(() -> {
-                        verify(jobsRepository, atLeast(1)).save(jobCaptor.capture());                        
-                        List<Job> values = jobCaptor.getAllValues();
-                        assertEquals("complete", values.get(0).getStatus(), "first saved job should show running");
-                        assertEquals(jobCompleted.getLog(), values.get(0).getLog());
-                });
-               
-        }
+                                .untilAsserted(() -> {
+                                        verify(jobsRepository, atLeast(1)).save(jobCaptor.capture());
+                                        List<Job> values = jobCaptor.getAllValues();
+                                        assertEquals("complete", values.get(0).getStatus(),
+                                                        "first saved job should show running");
+                                        assertEquals(jobCompleted.getLog(), values.get(0).getLog());
+                                });
 
-        @WithMockUser(roles = { "ADMIN" })
-        @Test
-        public void admin_can_launch_test_job_that_fails() throws Exception {
-
-                // arrange
-
-                User user = currentUserService.getUser();
-
-                Job jobStarted = Job.builder()
-                                .id(0L)
-                                .createdBy(user)
-                                .createdAt(null)
-                                .updatedAt(null)
-                                .status("running")
-                                .log("Hello World! from test job!")
-                                .build();
-
-                Job jobFailed = Job.builder()
-                                .id(0L)
-                                .createdBy(user)
-                                .createdAt(null)
-                                .updatedAt(null)
-                                .status("error")
-                                .log("Hello World! from test job!\nFail!")
-                                .build();
-
-                when(jobsRepository.save(eq(jobStarted))).thenReturn(jobStarted);
-                when(jobsRepository.save(eq(jobFailed))).thenReturn(jobFailed);
-
-                // act
-                MvcResult response = mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=3000").with(csrf()))
-                                .andExpect(status().isOk()).andReturn();
-
-                String responseString = response.getResponse().getContentAsString();
-                Job jobReturned = objectMapper.readValue(responseString, Job.class);
-
-                assertEquals("running", jobReturned.getStatus());
-
-                await().atMost(6, SECONDS)
-                .untilAsserted(() -> {
-                        verify(jobsRepository, atLeast(1)).save(jobCaptor.capture());                        
-                        List<Job> values = jobCaptor.getAllValues();
-                        assertEquals("error", values.get(0).getStatus(), "first saved job should show running");
-                        assertEquals(jobFailed.getLog(), values.get(0).getLog());
-                });
         }
 
         @WithMockUser(roles = { "ADMIN" })
@@ -232,7 +185,7 @@ public class JobsControllerTests extends ControllerTestCase {
                 Map<String, String> expectedMap = Map.of(
                                 "type", "IllegalArgumentException",
                                 "message", "sleepMs must be between 0 and 60000");
-                String expected = mapper.writeValueAsString(expectedMap);       
+                String expected = mapper.writeValueAsString(expectedMap);
                 MvcResult response = mockMvc
                                 .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=-1").with(csrf()))
                                 .andExpect(status().isBadRequest()).andReturn();
@@ -253,7 +206,7 @@ public class JobsControllerTests extends ControllerTestCase {
                 Map<String, String> expectedMap = Map.of(
                                 "type", "IllegalArgumentException",
                                 "message", "sleepMs must be between 0 and 60000");
-                String expected = mapper.writeValueAsString(expectedMap);       
+                String expected = mapper.writeValueAsString(expectedMap);
                 MvcResult response = mockMvc
                                 .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=60001").with(csrf()))
                                 .andExpect(status().isBadRequest()).andReturn();
@@ -279,5 +232,4 @@ public class JobsControllerTests extends ControllerTestCase {
                                 .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=60000").with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
         }
-
 }


### PR DESCRIPTION
In this PR, we try to resolve a flaky test by:

* separating it out into its own file, so that it has its only private Argument Captor, to try to avoid interactions with other tests
* make the test flexible for which of the calls to `save` has the `error` in it.
